### PR TITLE
Add support for FreeBSD

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -44,8 +44,8 @@ define awstats::conf(
 
   file { "${::awstats::params::config_dir_path}/awstats.${title}.conf":
     ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $::awstats::owner,
+    group   => $::awstats::group,
     mode    => '0644',
     content => template($real_template),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,8 @@
 class awstats(
   $config_dir_purge = false,
   $enable_plugins   = [],
+  $owner = $awstats::params::owner,
+  $group = $awstats::params::group,
 ) inherits ::awstats::params {
   validate_bool($config_dir_purge)
   validate_array($enable_plugins)
@@ -10,8 +12,8 @@ class awstats(
   package{ $::awstats::params::package_name: }
   -> file { $::awstats::params::config_dir_path:
     ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $owner,
+    group   => $group,
     mode    => '0755',
     recurse => true,
     purge   => $config_dir_purge,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,12 +4,21 @@
 #
 class awstats::params {
   case $::osfamily {
+    'FreeBSD': {
+      $package_name     = 'awstats'
+      $config_dir_path  = '/usr/local/etc/awstats'
+      $default_template = "${module_name}/awstats.conf.erb"
+      $owner            = 'root'
+      $group            = 'wheel'
+    }
     'RedHat': {
       case $::operatingsystemmajrelease {
         '6', '7': {
           $package_name     = 'awstats'
           $config_dir_path  = '/etc/awstats'
           $default_template = "${module_name}/awstats.conf.erb"
+          $owner            = 'root'
+          $group            = 'root'
         }
         default: {
           fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}") # lint:ignore:80chars
@@ -20,6 +29,8 @@ class awstats::params {
       $package_name     = 'awstats'
       $config_dir_path  = '/etc/awstats'
       $default_template = "${module_name}/awstats.conf.erb"
+      $owner            = 'root'
+      $group            = 'root'
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")


### PR DESCRIPTION
FreeBSD does not have a _root_ group. The equivalent is _wheel_.

Moreover, the permissions of the generated configuration files where 755 (although they are explicitely set to 644).  I guess this is due to the recursion on on the directory.  When not setting the mode of the directory, files get the correct permission.  The problem is unrelated but I was hacking in the area, so committed it quickly.  Please tell me if you prefer two PR.
