### PR TITLE
Fix legacy fact usage

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # This class should be considered private
 #
 class awstats::params {
-  case $::osfamily {
+  case fact('os.family') {
     'FreeBSD': {
       $package_name     = 'awstats'
       $config_dir_path  = '/usr/local/etc/awstats'
@@ -12,7 +12,7 @@ class awstats::params {
       $group            = 'wheel'
     }
     'RedHat': {
-      case $::operatingsystemmajrelease {
+      case fact('os.release.major') {
         '6', '7': {
           $package_name     = 'awstats'
           $config_dir_path  = '/etc/awstats'
@@ -21,7 +21,7 @@ class awstats::params {
           $group            = 'root'
         }
         default: {
-          fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}") # lint:ignore:80chars
+          fail("Module ${module_name} is not supported on operatingsystemmajrelease ${fact('os.release.major')}") # lint:ignore:80chars
         }
       }
     }
@@ -33,7 +33,7 @@ class awstats::params {
       $group            = 'root'
     }
     default: {
-      fail("Module ${module_name} is not supported on ${::operatingsystem}")
+      fail("Module ${module_name} is not supported on ${fact('os.family')}")
     }
   }
 }


### PR DESCRIPTION
This allows to test control-repos catalogs with onceover using factsets
that do not include legacy facts.
